### PR TITLE
chore: fix wrong company logo mapping in Main.css

### DIFF
--- a/import/keycloak-themes/catenax-central/login/resources/css/Main.css
+++ b/import/keycloak-themes/catenax-central/login/resources/css/Main.css
@@ -272,5 +272,5 @@ footer {
 .idp-main.idp24 { background-image: url("../img/IGS.png"); } /* IGS */
 .idp-main.idp25 { background-image: url("../img/TMDT.png"); } /* TMDT */
 .idp-main.idp26 { background-image: url("../img/Fraunhofer-IBP.png"); } /* Fraunhofer IBP */
-.idp-main.idp27 { background-image: url("../img/Fraunhofer-IBP.png"); } /* Fraunhofer IFF */
+.idp-main.idp27 { background-image: url("../img/Fraunhofer-IFF.png"); } /* Fraunhofer IFF */
 .idp-main.idp28 { background-image: url("../img/Bergische-Uni-Wuppertal.png"); } /* Bergische Uni */


### PR DESCRIPTION
## Description

This PR fixes an incorrect company logo mapping in `Main.css` for the IAM login selection page.

## Why

One company alias was linked to the wrong logo, which caused the wrong image to be shown before login. This fix ensures the correct logo is displayed for that company.

## Issue

N/A (follow-up fix from review feedback)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
